### PR TITLE
Upgrade pod cocoa_grinwallet to v1.0.4

### DIFF
--- a/ios/GrinWallet/GrinBridge.m
+++ b/ios/GrinWallet/GrinBridge.m
@@ -19,9 +19,11 @@
 
 @interface RCT_EXTERN_MODULE(GrinBridge, NSObject)
 
-RCT_EXTERN_METHOD(walletInit:(NSString*)state password:(NSString*)password resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(selectNearestNode:(NSString*)nodeApiHttpAddr resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(walletPhrase:(NSString*)state  resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(walletInit:(NSString*)state password:(NSString*)password is_12_phrases:(BOOL)is_12_phrases resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(walletPhrase:(NSString*)state resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(walletRecovery:(NSString*)state phrase:(NSString*)phrase resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
@@ -30,6 +32,8 @@ RCT_EXTERN_METHOD(walletRestore:(NSString*)state startIndex:(uint64_t)startIndex
 RCT_EXTERN_METHOD(walletRepair:(NSString*)state startIndex:(uint64_t)startIndex batchSize:(uint64_t)batchSize updateOutputs:(BOOL)updateOutputs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(checkPassword:(NSString*)state password:(NSString*)password resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(changePassword:(NSString*)state oldPassword:(NSString*)oldPassword  newPassword:(NSString*)newPassword resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(balance:(NSString*)state resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
@@ -40,6 +44,12 @@ RCT_EXTERN_METHOD(txsGet:(NSString*)state resolve:(RCTPromiseResolveBlock)resolv
 RCT_EXTERN_METHOD(txGet:(NSString*)state txSlateId:(NSString*)txSlateId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(txPost:(NSString*)state txSlateId:(NSString*)txSlateId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(listen:(NSString*)state resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(myRelayAddress:(NSString*)state resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(relayAddressQuery:(NSString*)state sixCode:(NSString*)sixCode resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(txCreate:(NSString*)state amount:(uint64_t)amount selectionStrategy:(NSString*)selectionStrategy message:(NSString*)message targetSlateVersion:(int64_t)targetSlateVersion resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/GrinWallet/GrinBridge.swift
+++ b/ios/GrinWallet/GrinBridge.swift
@@ -43,9 +43,15 @@ class GrinBridge: NSObject {
       return false
     }
   
-    @objc func walletInit(_ state: String, password: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+    @objc func selectNearestNode(_ nodeApiHttpAddr: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
       var error: UInt8 = 0
-      let cResult = grin_wallet_init(state, password, &error)
+      let cResult = select_nearest_node(nodeApiHttpAddr, &error)
+      handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
+    }
+
+  @objc func walletInit(_ state: String, password: String, is_12_phrases: Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+      var error: UInt8 = 0
+      let cResult = grin_wallet_init(state, password, is_12_phrases, &error)
       handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
     }
   
@@ -79,6 +85,12 @@ class GrinBridge: NSObject {
       handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
     }
   
+    @objc func changePassword(_ state:String, oldPassword: String, newPassword: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+      var error: UInt8 = 0
+      let cResult = grin_wallet_change_password(state, oldPassword, newPassword, &error)
+      handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
+    }
+
     @objc func balance(_ state: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         var error: UInt8 = 0
         let cResult = grin_get_balance(state, &error)
@@ -100,6 +112,24 @@ class GrinBridge: NSObject {
     @objc func txGet(_ state: String, txSlateId: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         var error: UInt8 = 0
         let cResult = grin_tx_retrieve(state, txSlateId, &error)
+        handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
+    }
+  
+    @objc func listen(_ state: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+      var error: UInt8 = 0
+      let cResult = grin_listen(state, &error)
+      handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
+    }
+  
+    @objc func myRelayAddress(_ state: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+      var error: UInt8 = 0
+      let cResult = my_grin_relay_addr(state, &error)
+      handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
+    }
+  
+    @objc func relayAddressQuery(_ state: String, sixCode: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+      var error: UInt8 = 0
+      let cResult = grin_relay_addr_query(state, sixCode, &error)
         handleCResult(error:error, cResult:cResult!, resolve: resolve, reject: reject)
     }
     

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,7 +6,7 @@ project 'GrinWallet.xcodeproj'
 target 'GrinWallet' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
   # use_frameworks!
-  pod 'cocoa_grinwallet', :git => 'https://github.com/gottstech/archived-cocoa_grinwallet.git', :commit => '0ff25fe6864db8a859a8e111d215d86bce4c1922'
+  pod 'cocoa_grinwallet', :git => 'https://github.com/gottstech/cocoa_grinwallet.git', :tag => 'v1.0.4'
   # Pods for GrinWallet
 
   target 'GrinWallet-tvOSTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
-  - cocoa_grinwallet (0.0.1)
+  - cocoa_grinwallet (1.0.4)
 
 DEPENDENCIES:
-  - cocoa_grinwallet (from `https://github.com/gottstech/archived-cocoa_grinwallet.git`, commit `0ff25fe6864db8a859a8e111d215d86bce4c1922`)
+  - cocoa_grinwallet (from `https://github.com/gottstech/cocoa_grinwallet.git`, tag `v1.0.4`)
 
 EXTERNAL SOURCES:
   cocoa_grinwallet:
-    :commit: 0ff25fe6864db8a859a8e111d215d86bce4c1922
-    :git: https://github.com/gottstech/archived-cocoa_grinwallet.git
+    :git: https://github.com/gottstech/cocoa_grinwallet.git
+    :tag: v1.0.4
 
 CHECKOUT OPTIONS:
   cocoa_grinwallet:
-    :commit: 0ff25fe6864db8a859a8e111d215d86bce4c1922
-    :git: https://github.com/gottstech/archived-cocoa_grinwallet.git
+    :git: https://github.com/gottstech/cocoa_grinwallet.git
+    :tag: v1.0.4
 
 SPEC CHECKSUMS:
-  cocoa_grinwallet: 14cead88c58833710156f3ec2d53a316e449bd04
+  cocoa_grinwallet: 845fac985d318f2882c48b73a31dcd76ef9451e2
 
-PODFILE CHECKSUM: 149a47f4622fa0eca0d799aa2848522de8fb44cb
+PODFILE CHECKSUM: 90221ee6fb75c49b4cf7a6e36b3cda3b8422799a
 
 COCOAPODS: 1.7.5

--- a/ios/get_grinwallet_libs.sh
+++ b/ios/get_grinwallet_libs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+version=`grep " pod 'cocoa_grinwallet'" Podfile | sed "s/.*:tag => '\(.*\)'/\1/"`
+
+mkdir -p Pods/cocoa_grinwallet/cocoa_grinwallet/Library && cd Pods/cocoa_grinwallet/cocoa_grinwallet/Library && rm -f libgrinwallet* || exit 1
+
+wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_aarch64-apple-ios.a || exit 1
+
+wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_armv7s-apple-ios.a || exit 1
+
+wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_x86_64-apple-ios.a || exit 1
+
+printf "3 libs have been downloaded successfully\n"
+
+cd - > /dev/null || exit 1
+ls -l Pods/cocoa_grinwallet/cocoa_grinwallet/Library


### PR DESCRIPTION
Refer to `cocoa_grinwallet` v1.0.4 release:  https://github.com/gottstech/cocoa_grinwallet/releases/tag/v1.0.4

For the difference between `v1.0.3` APIs and `v1.0.4` APIs:
- [difference](https://github.com/gottstech/cocoa_grinwallet/wiki/Grin-Wallet-Cocoa-API-Guide/_compare/300bd19715d576f91167b0eb1d8e999d030d7af9...29bae7595eb64295d9cb35f520f9953e2e27a0bb)

Please note the broken API change since `v1.0.3`:
- The `walletInit` take 3 parameters instead of 2 parameters in `v1.0.2`. [Read here](https://github.com/gottstech/cocoa_grinwallet/wiki/Grin-Wallet-Cocoa-API-Guide#1-wallet-init) for detail.